### PR TITLE
BACKLOG-13933: update java source/target to java 1.6

### DIFF
--- a/tags/ehcache-1.7.2/core/pom.xml
+++ b/tags/ehcache-1.7.2/core/pom.xml
@@ -116,8 +116,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
recent versions of maven-compiler-plugin no longer support Java 1.5 as source/target

## JIRA
https://jira.jahia.org/browse/BACKLOG-13933